### PR TITLE
Retry with updating ip address

### DIFF
--- a/lib/kitchen/driver/vsphere.rb
+++ b/lib/kitchen/driver/vsphere.rb
@@ -38,8 +38,8 @@ module Kitchen
         begin
           state[:hostname] = server.public_ip_address
           timeout(5) {
-            SSH.new(state[:hostname], config[:username],
-              { :port => config[:port], :logger => logger }).wait
+            wait_for_sshd(state[:hostname], config[:username],
+              { :port => config[:port] })
             info "SSH connected to #{state[:hostname]}:#{config[:port]}"
           }
         rescue Timeout::Error


### PR DESCRIPTION
Some of our VSphere VMs come up with an automatic private IP addressing (APIPA, 169.254.x.x) number at the start, which won't work from the workstation running test-kitchen.  This PR goes back to VSphere for the IP address as it retries, so it will use the correct one once DHCP has kicked in successfully.
